### PR TITLE
Add SavedPin model and save endpoint route

### DIFF
--- a/backend/.env.text
+++ b/backend/.env.text
@@ -1,4 +1,0 @@
-DATABASE_URL="postgresql://admin:feyU7m25zfK0XWaNygAKYUpZp6C4KBza@dpg-d0s72oc9c44c73crocg0-a.frankfurt-postgres.render.com/pin_db_w2zd"
-PORT = 4000
-JWT_SECRET=mysecretkey
-JWT_EXPIRES_IN=30d

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   Reaction  Reaction[]
   pins      Pin[]
   comments  Comment[]
+  savedPins SavedPin[]
 }
 
 model Pin {
@@ -45,6 +46,7 @@ model Pin {
   reactions Reaction[]
   comments  Comment[]
   tags      String[]
+  savedBy SavedPin[]
 }
 
 model Comment {
@@ -57,4 +59,14 @@ model Comment {
   content   String
 
   @@unique([userId, pinId]) // prevent duplicate Comments
+}
+model SavedPin {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  pin       Pin      @relation(fields: [pinId], references: [id])
+  pinId     Int
+  savedAt   DateTime @default(now())
+
+  @@unique([userId, pinId])
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,6 +1,6 @@
 import dotenv from "dotenv";
 dotenv.config();
-
+import saveRoutes from "./routes/saveRoute.js";
 import express from "express";
 import cors from "cors";
 import reactionsRoutes from "./routes/reactionsRoute.js";
@@ -20,6 +20,7 @@ app.use("/api/reactions", reactionsRoutes);
 app.use("/api/user", userRoutes);
 app.use("/api/comments", commentsRoutes);
 app.use("/api/pins", pinRoutes);
+app.use("/api/save", saveRoutes);
 
 // get
 app.get("/", (req, res) => {

--- a/backend/src/routes/saveRoute.js
+++ b/backend/src/routes/saveRoute.js
@@ -1,0 +1,32 @@
+import express from "express";
+import { PrismaClient } from "@prisma/client";
+
+const router = express.Router();
+const prisma = new PrismaClient();
+
+router.post("/", async (req, res) => {
+  const { userId, pinId } = req.body;
+
+  if (!userId || !pinId) {
+    return res.status(400).json({ error: "userId and pinId are required" });
+  }
+
+  try {
+    const saved = await prisma.savedPin.create({
+      data: {
+        userId,
+        pinId,
+      },
+    });
+
+    res.status(201).json({ message: "Pin saved!", saved });
+  } catch (error) {
+    if (error.code === 'P2002') {
+      return res.status(409).json({ error: "Pin already saved!" });
+    }
+    console.error("Save error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
This PR introduces the functionality that allows a user to save a post (pin) using a dedicated API endpoint. The feature follows the intended behavior seen in platforms like Pinterest, where users can store pins for later access.

Features Added
New Prisma model: SavedPin

Stores the relationship between User and Pin

Contains userId, pinId, and savedAt

Prevents duplicate saves via a unique constraint on (userId, pinId)

API Route: POST /api/save

Accepts JSON body: { userId, pinId }

Validates input

Saves the pin only if it hasn't already been saved

Returns appropriate error if duplicate or internal failure

Schema Update:

Linked SavedPin to both User and Pin models

Schema validated and synced with DB

Testing

Tested using Postman:

Successful save

Verified SavedPin records in PostgreSQL using DBeaver


**Future Aspect(to be done later):** 

An endpoint to unsave a pin

A route to list all saved pins for a user